### PR TITLE
Use es6 lib of TweetNaCl

### DIFF
--- a/js/lib/nacl-fast-es.js
+++ b/js/lib/nacl-fast-es.js
@@ -1,5 +1,5 @@
-(function(nacl) {
-'use strict';
+const nacl = {};
+export default nacl;
 
 // Ported in 2014 by Dmitry Chestnykh and Devi Mandiri.
 // Public domain.
@@ -2041,12 +2041,11 @@ function unpackneg(r, p) {
 }
 
 function crypto_sign_open(m, sm, n, pk) {
-  var i, mlen;
+  var i;
   var t = new Uint8Array(32), h = new Uint8Array(64);
   var p = [gf(), gf(), gf(), gf()],
       q = [gf(), gf(), gf(), gf()];
 
-  mlen = -1;
   if (n < 64) return -1;
 
   if (unpackneg(q, pk)) return -1;
@@ -2068,8 +2067,7 @@ function crypto_sign_open(m, sm, n, pk) {
   }
 
   for (i = 0; i < n; i++) m[i] = sm[i + 64];
-  mlen = n;
-  return mlen;
+  return n;
 }
 
 var crypto_secretbox_KEYBYTES = 32,
@@ -2373,5 +2371,3 @@ nacl.setPRNG = function(fn) {
     }
   }
 })();
-
-})(typeof module !== 'undefined' && module.exports ? module.exports : (self.nacl = self.nacl || {}));

--- a/js/src-test/browsertests/test.js
+++ b/js/src-test/browsertests/test.js
@@ -1,7 +1,6 @@
 import saltchannel from './../../src/saltchannel.js';
 import * as util from './../../lib/util.js';
-
-const nacl = typeof module !== 'undefined' && module.exports ? require('../../lib/nacl-fast.js') : self.nacl;
+import nacl from './../../lib/nacl-fast-es.js';
 
 let clientSecret = util.hex2Uint8Array('fd2956eb37782aabddc97eaf3b9e1b075f4976770db56c11e866e8763fa073d8' +
             '9cace2ed6af2e108bbabc69c0bb7f3e62a4c0bf59ac2296811a09e480bf7b0f7');

--- a/js/src-test/index.html
+++ b/js/src-test/index.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html>
 <head>
     <meta charset="utf-8" />
-    <script src="../lib/nacl-fast.js"></script>
     <script type="module">
         import {run} from './browsertests/test.js';
         run('a1a2');

--- a/js/src-test/tests/a1a2test.js
+++ b/js/src-test/tests/a1a2test.js
@@ -1,11 +1,11 @@
 import saltChannelSession from './../../src/saltchannel.js';
 import * as util from './../../lib/util.js';
-
-const nacl = require('./../../lib/nacl-fast.js')
+import nacl from './../../lib/nacl-fast-es.js';
 
 let serverSecret =
 	util.hex2Uint8Array('7a772fa9014b423300076a2ff646463952f141e2aa8d98263c690c0d72eed52d' +
 						'07e28d4ee32bfdc4b07d41c92193c0c25ee6b3094c6296f373413b373d36168b')
+
 let serverSigKeyPair = nacl.sign.keyPair.fromSecretKey(serverSecret)
 
 let mockSocket = {

--- a/js/src-test/tests/handshaketest.js
+++ b/js/src-test/tests/handshaketest.js
@@ -1,8 +1,7 @@
 import saltChannelSession from './../../src/saltchannel.js';
 import * as util from './../../lib/util.js';
+import nacl from './../../lib/nacl-fast-es.js';
 import getTimeChecker from './../../src/time/typical-time-checker.js';
-
-const nacl = require('./../../lib/nacl-fast.js')
 
 let clientSecret =
     util.hex2Uint8Array('fd2956eb37782aabddc97eaf3b9e1b075f4976770db56c11e866e8763fa073d8' +

--- a/js/src-test/tests/sessiontest.js
+++ b/js/src-test/tests/sessiontest.js
@@ -1,9 +1,8 @@
 import saltChannelSession from './../../src/saltchannel.js';
 import * as util from './../../lib/util.js';
+import nacl from './../../lib/nacl-fast-es.js';
 import getTimeKeeper from './../../src/time/typical-time-keeper.js';
 import getNullTimeKeeper from './../../src/time/null-time-keeper.js';
-
-const nacl = require('./../../lib/nacl-fast.js')
 
 
 const session1M1Bytes = util.hex2ab('534376320100000000008520f0098930a754748b7ddcb43ef75a0dbf3a0d26381af4eba4a98eaa9b4e6a')

--- a/js/src/saltchannel.js
+++ b/js/src/saltchannel.js
@@ -1,9 +1,8 @@
 import * as util from './../lib/util.js';
+import nacl from './../lib/nacl-fast-es.js';
 import getTimeKeeper from './time/typical-time-keeper.js';
 import getTimeChecker from './time/typical-time-checker.js';
 import getNullTimeChecker from './time/null-time-checker.js';
-
-const nacl = typeof module !== 'undefined' && module.exports ? require('./../lib/nacl-fast.js') : self.nacl;
 
 /**
  * JavaScript implementation of Salt Channel v2


### PR DESCRIPTION
Uses https://github.com/hakanols/tweetnacl-es6
An es6 version of the previous included TweetNaCl. Only minimal changes.
This enables better cross browser and node use. See changes in tests.